### PR TITLE
Correctly join mailer hyperlinks (closes #313)

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', "#{root_url}confirmation?#{{ :confirmation_token => @token }.to_query}" %></p>
+<p><%= link_to 'Confirm my account', URI.join(root_url, '/confirmation', "?confirmation_token=#{@token}").to_s %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', "#{root_url}reset_password?#{{ :reset_password_token => @token }.to_query}" %></p>
+<p><%= link_to 'Change my password', URI.join(root_url, '/reset_password', "?reset_password_token=#{@token}").to_s %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>


### PR DESCRIPTION
Fix hyperlinks in email sent out by email registration.