### PR TITLE
Frontend presentation toolbar cleanup

### DIFF
--- a/client/app/presentationals/components/presentation-view/PresentationViewToolbar.jsx
+++ b/client/app/presentationals/components/presentation-view/PresentationViewToolbar.jsx
@@ -1,20 +1,26 @@
 import React, { Component } from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { compose } from 'recompose';
+
+import { getConversationCountForActiveSlide } from 'selectors/entities/conversations';
+import { getSlideCountById } from 'selectors/entities/decks';
+import { getNumberOfActiveSlideInPresentation } from 'selectors/app/presentation';
 
 class PresentationToolbar extends Component {
 
   constructor() {
     super();
     this.handleNavigation = this.handleNavigation.bind(this);
+    // this.renderSlideNumbers = this.renderSlideNumbers.bind(this);
   }
   componentDidMount() {
     window.addEventListener('keydown', this.handleNavigation);
   }
 
   componentWillUpdate(nextProps) {
-    console.log(nextProps);
-
     const { annotationMode } = nextProps;
 
     if (!annotationMode) {
@@ -48,18 +54,22 @@ class PresentationToolbar extends Component {
   }
 
   render() {
-    const { deckId } = this.props;
+    const { deckId, conversationCount, deckLength, slideNumber } = this.props;
+    const conversationCountIconClass = conversationCount ? 'fa-comment' : 'fa-comment-o';
 
     return (
       <div className="c_presentation-view-toolbar">
         <div className="c_presentation-view-toolbar__wrapper">
           <menu className="c_presentation-view-toolbar__list">
             <li className="c_presentation-view-toolbar__item">
+              {slideNumber} / {deckLength}
+            </li>
+            <li className="c_presentation-view-toolbar__item">
               <button
                 className="c_presentation-view-toolbar__button"
                 onClick={() => this.props.viewFirstSlide()}
               >
-                First
+                <i className={'fa fa-angle-double-left'} aria-hidden="true" />
               </button>
             </li>
             <li className="c_presentation-view-toolbar__item">
@@ -67,7 +77,7 @@ class PresentationToolbar extends Component {
                 className="c_presentation-view-toolbar__button"
                 onClick={() => this.props.viewPreviousSlide()}
               >
-                Previous
+                <i className={'fa fa-angle-left'} aria-hidden="true" />
               </button>
             </li>
             <li className="c_presentation-view-toolbar__item">
@@ -75,7 +85,7 @@ class PresentationToolbar extends Component {
                 className="c_presentation-view-toolbar__button"
                 onClick={() => this.props.viewNextSlide()}
               >
-                Next
+                <i className={'fa fa-angle-right'} aria-hidden="true" />
               </button>
             </li>
             <li className="c_presentation-view-toolbar__item">
@@ -83,7 +93,7 @@ class PresentationToolbar extends Component {
                 className="c_presentation-view-toolbar__button"
                 onClick={() => this.props.viewLastSlide()}
               >
-                Last
+                <i className={'fa fa-angle-double-right'} aria-hidden="true" />
               </button>
             </li>
             <li className="c_presentation-view-toolbar__item">
@@ -91,7 +101,7 @@ class PresentationToolbar extends Component {
                 className="c_presentation-view-toolbar__button"
                 onClick={() => this.props.history.push('/')}
               >
-                Dashboard
+                <i className={'fa fa-bars'} aria-hidden="true" />
               </button>
             </li>
             <li className="c_presentation-view-toolbar__item">
@@ -99,7 +109,7 @@ class PresentationToolbar extends Component {
                 className="c_presentation-view-toolbar__button"
                 onClick={() => this.props.history.push(`/print/${deckId}`)}
               >
-                Course Mode
+                <i className={'fa fa-file-text-o'} aria-hidden="true" />
               </button>
             </li>
             <li className="c_presentation-view-toolbar__item">
@@ -107,7 +117,7 @@ class PresentationToolbar extends Component {
                 className="c_presentation-view-toolbar__button"
                 onClick={() => this.props.toggleAnnotationMode()}
               >
-                Toggle Annotation Mode
+                <i className={`fa ${conversationCountIconClass}`} aria-hidden="true" /> {`(${conversationCount})`}
               </button>
             </li>
           </menu>
@@ -126,7 +136,20 @@ PresentationToolbar.propTypes = {
   viewLastSlide: PropTypes.func.isRequired,
   toggleAnnotationMode: PropTypes.func.isRequired,
   annotationMode: PropTypes.bool.isRequired,
+  conversationCount: PropTypes.number.isRequired,
+  deckLength: PropTypes.number.isRequired,
+  slideNumber: PropTypes.number.isRequired,
 };
 
-
-export default withRouter(PresentationToolbar);
+export default compose(
+  withRouter,
+  connect(
+    (state, props) => {
+      return {
+        conversationCount: getConversationCountForActiveSlide(state),
+        deckLength: getSlideCountById(state, props.deckId),
+        slideNumber: getNumberOfActiveSlideInPresentation(state, props.deckId),
+      };
+    },
+  ),
+)(PresentationToolbar);

--- a/client/app/sagas/annotations/addConversationCommentSaga.js
+++ b/client/app/sagas/annotations/addConversationCommentSaga.js
@@ -1,7 +1,8 @@
 import { takeLatest, select, call, put } from 'redux-saga/effects';
 import { SubmissionError } from 'redux-form';
 
-import { getActiveSlideId, getActiveDeckId, getActiveConversationId } from 'selectors/app/annotations';
+import { getActiveDeckId, getActiveConversationId } from 'selectors/app/annotations';
+import { getActiveSlideId } from 'selectors/app/presentation';
 import { getCurrentUserId } from 'selectors/app/auth';
 import { ADD_CONVERSATION_COMMENT, FETCH_CONVERSATION_COMMENTS } from 'actions/entities/conversation-comments';
 import { SIGNOUT } from 'actions/signoutActions';
@@ -26,7 +27,7 @@ export function* doAddConversationComment(action) {
   }
   catch (error) {
     if (error.statusCode === 401) {
-      yield put({type: SIGNOUT});
+      yield put({ type: SIGNOUT });
     }
     const errorMessage = yield { _error: 'Something went wrong on our end.' };
     yield call(reject, new SubmissionError(errorMessage));

--- a/client/app/sagas/annotations/addConversationSaga.js
+++ b/client/app/sagas/annotations/addConversationSaga.js
@@ -1,7 +1,8 @@
 import { takeLatest, select, call, put } from 'redux-saga/effects';
 import { SubmissionError } from 'redux-form';
 
-import { getActiveSlideId, getActiveDeckId } from 'selectors/app/annotations';
+import { getActiveDeckId } from 'selectors/app/annotations';
+import { getActiveSlideId } from 'selectors/app/presentation';
 import { getCurrentUserId } from 'selectors/app/auth';
 import { ADD_CONVERSATION } from 'actions/entities/conversations';
 import { SIGNOUT } from 'actions/signoutActions';

--- a/client/app/selectors/app/annotations/index.js
+++ b/client/app/selectors/app/annotations/index.js
@@ -2,10 +2,6 @@ export const getActiveDeckId = (state) => {
   return state.app.presentationView.activeDeckId;
 };
 
-export const getActiveSlideId = (state) => {
-  return state.app.presentationView.activeSlideId;
-};
-
 export const getActiveConversationId = (state) => {
   return state.app.annotations.activeConversationId;
 };

--- a/client/app/selectors/app/presentation/index.js
+++ b/client/app/selectors/app/presentation/index.js
@@ -1,0 +1,17 @@
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+import { getSlideIdsById } from 'selectors/entities/decks';
+
+export const getActiveSlideId = (state) => {
+  return state.app.presentationView.activeSlideId;
+};
+
+export const getNumberOfActiveSlideInPresentation = createSelector(
+  getActiveSlideId,
+  getSlideIdsById,
+  (activeSlideId, slideIds) => {
+    const slideIndexInDeck = _.indexOf(slideIds, activeSlideId);
+
+    return slideIndexInDeck + 1;
+  },
+);

--- a/client/app/selectors/entities/conversations/index.js
+++ b/client/app/selectors/entities/conversations/index.js
@@ -13,4 +13,13 @@ const getConversationsForActiveSlide = createSelector(
   },
 );
 
+export const getConversationCountForActiveSlide = createSelector(
+  getActiveSlideId,
+  getConversationsById,
+  (activeSlideId, conversations) => {
+    const conversationsForSlide = _.filter(conversations, { contentItemId: activeSlideId });
+    return conversationsForSlide.length;
+  },
+);
+
 export default getConversationsForActiveSlide;

--- a/client/app/selectors/entities/decks/index.js
+++ b/client/app/selectors/entities/decks/index.js
@@ -7,3 +7,17 @@ export const getDecksById = (state) => {
 export const getDeckById = (state, id) => {
   return state.entities.decks.byId[id];
 };
+
+export const getSlideIdsById = (state, id) => {
+  if (state.entities.decks.byId[id]) {
+    return state.entities.decks.byId[id].slideIds;
+  }
+  return [];
+};
+
+export const getSlideCountById = (state, id) => {
+  if (state.entities.decks.byId[id]) {
+    return state.entities.decks.byId[id].slideIds.length;
+  }
+  return 0;
+};

--- a/client/assets/stylesheets/scss/theme/components/_presentation-view-toolbar.scss
+++ b/client/assets/stylesheets/scss/theme/components/_presentation-view-toolbar.scss
@@ -9,7 +9,7 @@
   @include color--emphasis;
 
   position: fixed;
-  top: 0;
+  bottom: 0;
   right: 0;
   left: 0;
 

--- a/client/assets/stylesheets/scss/theme/components/_presentation-view.scss
+++ b/client/assets/stylesheets/scss/theme/components/_presentation-view.scss
@@ -9,4 +9,8 @@
     // height: 88vh; // temporarily make slide smaller than fullscreen so that pres. mode UI doesn't overlap it
     height: 100vh;
   }
+  // Hide slide numbers in presentation view.
+  .ows-slide::after {
+    display: none;
+  }
 }


### PR DESCRIPTION
This PR adds icons, conversation count and slide numbering to the toolbar.

What still needs to happen is to remove the numbering on the slides themselves and place the bar at the bottom again. @Dromin I didn't want to mess with the classes and div nesting too much, but if you tell me what to do I can do it myself. 