### PR TITLE
Frontend add annotation overview panel

### DIFF
--- a/client/app/presentationals/components/annotations/AnnotationSidePanel.jsx
+++ b/client/app/presentationals/components/annotations/AnnotationSidePanel.jsx
@@ -10,6 +10,7 @@ import ConversationList from './conversations/ConversationList';
 import ConversationPanel from './conversations/ConversationPanel';
 import AddConversationPanel from './conversations/AddConversationPanel';
 import PrivateNotePanel from './conversations/PrivateNotePanel';
+import OverviewPanel from './conversations/OverviewPanel';
 
 
 class AnnotationSidePanel extends Component {
@@ -22,12 +23,15 @@ class AnnotationSidePanel extends Component {
     this.showPrivateNotePanel = this.showPrivateNotePanel.bind(this);
     this.closePrivateNotePanel = this.closePrivateNotePanel.bind(this);
     this.closeConversationPanel = this.closeConversationPanel.bind(this);
+    this.showOverviewPanel = this.showOverviewPanel.bind(this);
+    this.closeOverviewPanel = this.closeOverviewPanel.bind(this);
 
     this.state = {
       showPrivateNoteForm: false,
       showAddConversationPanel: false,
       showConversationPanel: false,
       showPrivateNotePanel: false,
+      showOverviewPanel: false,
     };
   }
 
@@ -50,6 +54,10 @@ class AnnotationSidePanel extends Component {
     this.setState({ showAddConversationPanel: false });
   }
 
+  closeOverviewPanel() {
+    this.setState({ showOverviewPanel: false });
+  }
+
   closePrivateNotePanel() {
     this.setState({ showPrivateNotePanel: false });
   }
@@ -68,6 +76,11 @@ class AnnotationSidePanel extends Component {
     this.setState({ showPrivateNotePanel: true });
   }
 
+  showOverviewPanel() {
+    this.setState({ showConversationPanel: false });
+    this.setState({ showOverviewPanel: true });
+  }
+
   renderContent() {
     if (this.state.showAddConversationPanel) {
       return (
@@ -76,6 +89,14 @@ class AnnotationSidePanel extends Component {
           showConversationPanel={this.showConversationPanel}
         />
 
+      );
+    }
+
+    if (this.state.showOverviewPanel) {
+      return (
+        <OverviewPanel
+          closeOverviewPanel={this.closeOverviewPanel}
+        />
       );
     }
 
@@ -100,6 +121,8 @@ class AnnotationSidePanel extends Component {
         <button className="close-btn" onClick={() => this.props.toggleAnnotationMode()}>
           &times;
         </button>
+        <button onClick={this.showOverviewPanel}>Annotation Overview</button>
+
         <h3>
           <strong>Conversations for current slide</strong>
         </h3>

--- a/client/app/presentationals/components/annotations/AnnotationSidePanel.jsx
+++ b/client/app/presentationals/components/annotations/AnnotationSidePanel.jsx
@@ -68,6 +68,7 @@ class AnnotationSidePanel extends Component {
 
   showConversationPanel(conversationId) {
     this.props.setActiveConversationId(conversationId);
+    this.setState({ showOverviewPanel: false });
     this.setState({ showConversationPanel: true });
   }
 
@@ -96,6 +97,7 @@ class AnnotationSidePanel extends Component {
       return (
         <OverviewPanel
           closeOverviewPanel={this.closeOverviewPanel}
+          showConversationPanel={this.showConversationPanel}
         />
       );
     }

--- a/client/app/presentationals/components/annotations/conversations/OverviewPanel.jsx
+++ b/client/app/presentationals/components/annotations/conversations/OverviewPanel.jsx
@@ -19,7 +19,7 @@ const sortConversationsBySlide = (conversations) => {
 };
 
 function OverviewPanel(props) {
-  const { closeOverviewPanel, conversations, setActiveSlide } = props;
+  const { closeOverviewPanel, showConversationPanel, conversations, setActiveSlide } = props;
 
   function renderConversations(conversations) {
     const conversationsBySlide = sortConversationsBySlide(conversations);
@@ -33,8 +33,10 @@ function OverviewPanel(props) {
             <li key={slideNumber}>
               <a href="#" onClick={() => setActiveSlide(slideId)}><h4>Slide {slideNumber}</h4></a>
               {conversationsBySlide[slideId].map((conversation) => {
+                const { id, title, commentCount, createdTimeAgo } = conversation;
                 return (<div>
-                  {conversation.title}
+                  <p><strong>{title} </strong></p>
+                  <a href="#" onClick={() => showConversationPanel(id)}>View</a> - {commentCount} comments - Posted {createdTimeAgo}
                 </div>);
               })
               }

--- a/client/app/presentationals/components/annotations/conversations/OverviewPanel.jsx
+++ b/client/app/presentationals/components/annotations/conversations/OverviewPanel.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { getConversationsById } from 'selectors/entities/conversations';
+import { setActiveSlide } from 'actions/app/presentation-view';
+
+const sortConversationsBySlide = (conversations) => {
+  const conversationsPerSlide = {};
+
+  Object.keys(conversations).forEach((key) => {
+    const { id, title, createdTimeAgo, commentCount, contentItemId } = conversations[key];
+
+    (conversationsPerSlide[contentItemId] = conversationsPerSlide[contentItemId] || []).push({ id, title, contentItemId, createdTimeAgo, commentCount });
+  });
+
+  return conversationsPerSlide;
+};
+
+function OverviewPanel(props) {
+  const { closeOverviewPanel, conversations, setActiveSlide } = props;
+
+  function renderConversations(conversations) {
+    const conversationsBySlide = sortConversationsBySlide(conversations);
+
+    return (
+      <ul>
+        {Object.keys(conversationsBySlide).map((slideId) => {
+          const slideNumber = parseInt(slideId.slice(3)) + 1;
+
+          return (
+            <li key={slideNumber}>
+              <a href="#" onClick={() => setActiveSlide(slideId)}><h4>Slide {slideNumber}</h4></a>
+              {conversationsBySlide[slideId].map((conversation) => {
+                return (<div>
+                  {conversation.title}
+                </div>);
+              })
+              }
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  return (
+    <div>
+      <button className="close-btn fa fa-chevron-left fa-6" onClick={() => closeOverviewPanel()} />
+      <h3><strong>Annotations Overview</strong></h3>
+      { conversations ? renderConversations(conversations) : <div><p>Hello</p></div>}
+    </div>
+  );
+}
+
+OverviewPanel.propTypes = {
+  closeOverviewPanel: PropTypes.func.isRequired,
+};
+
+export default connect(
+  (state) => {
+    return { conversations: getConversationsById(state) };
+  },
+  (dispatch) => {
+    return bindActionCreators({ setActiveSlide }, dispatch);
+  },
+)(OverviewPanel);


### PR DESCRIPTION
New feature that allows users to view an annotation overview panel where they can visit all annotations in the deck, sorted by slide (which they can also visit)

<img width="1440" alt="screen shot 2017-10-11 at 15 35 43" src="https://user-images.githubusercontent.com/19598519/31443629-412c0cd6-ae9a-11e7-8ff4-aa660f001aa4.png">
<img width="1440" alt="screen shot 2017-10-11 at 15 35 48" src="https://user-images.githubusercontent.com/19598519/31443630-414dc4fc-ae9a-11e7-8d28-a3c77e6793b1.png">
